### PR TITLE
Fix for mouse scroll PC(ignore)

### DIFF
--- a/src/main/java/ca/landonjw/mixin/pc/InfoWidgetMixin.java
+++ b/src/main/java/ca/landonjw/mixin/pc/InfoWidgetMixin.java
@@ -1,0 +1,42 @@
+package ca.landonjw.mixin.pc;
+
+import com.cobblemon.mod.common.client.gui.summary.widgets.SoundlessWidget;
+import com.cobblemon.mod.common.client.gui.summary.widgets.screens.info.InfoWidget;
+import com.cobblemon.mod.common.pokemon.Pokemon;
+import ca.landonjw.HAHighlighterRenderer;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.network.chat.Component;
+import org.jetbrains.annotations.NotNull;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(InfoWidget.class)        // Feature added by RIze2kNight, 2024
+public abstract class InfoWidgetMixin extends SoundlessWidget {
+    @Shadow(remap = false) @Final private static int ROW_HEIGHT;
+    @Shadow(remap = false) @Final private Pokemon pokemon;
+
+    public InfoWidgetMixin(int pX, int pY, int pWidth, int pHeight, @NotNull Component component) {
+        super(pX, pY, pWidth, pHeight, component);
+    }
+
+    @Inject(
+        method = "renderWidget",
+        at = @At(
+                value = "RETURN"
+        )
+    )
+    protected void renderWidget(GuiGraphics context, int pMouseX, int pMouseY, float pPartialTicks, CallbackInfo ci) {
+        if(pokemon != null){
+            var abilityWidget = HAHighlighterRenderer.INSTANCE.renderSummary(this.getX(),this.getY(), ROW_HEIGHT,this.width,pokemon);
+            if(abilityWidget != null){
+                abilityWidget.render(context, pMouseX, pMouseY, pPartialTicks);
+            }
+        }
+    }
+
+
+}

--- a/src/main/java/ca/landonjw/mixin/pc/PCGUIMixin.java
+++ b/src/main/java/ca/landonjw/mixin/pc/PCGUIMixin.java
@@ -1,26 +1,39 @@
 package ca.landonjw.mixin.pc;
 
 import ca.landonjw.GUIHandler;
+import ca.landonjw.HAHighlighterRenderer;
+import ca.landonjw.JumpPCBoxWidget;
+import ca.landonjw.OverridedUIRenderer;
 import com.cobblemon.mod.common.client.gui.pc.PCGUI;
 import com.cobblemon.mod.common.client.gui.pc.StorageWidget;
 import com.cobblemon.mod.common.client.keybind.CobblemonKeyBinds;
 import com.cobblemon.mod.common.client.storage.ClientPC;
 import com.cobblemon.mod.common.mixin.accessor.KeyBindingAccessor;
+import com.cobblemon.mod.common.pokemon.Pokemon;
+import net.minecraft.ChatFormatting;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.network.chat.Component;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import static com.cobblemon.mod.common.client.gui.pc.PCGUI.*;
 
 @Mixin(PCGUI.class)
 public abstract class PCGUIMixin extends Screen {
 
     @Shadow(remap = false) private StorageWidget storageWidget;
     @Final @Shadow(remap = false) private ClientPC pc;
+
+    @Unique private JumpPCBoxWidget jumpPCBoxWidget;
+    @Shadow(remap = false) private Pokemon previewPokemon = null;
 
     protected PCGUIMixin(Component component) {
         super(component);
@@ -45,6 +58,11 @@ public abstract class PCGUIMixin extends Screen {
             storageWidget.setBox(newBox);
         }
 
+        // If JumpPCBoxWidget is set, unfocus the EditBox to prevent de-synced box numbers
+        if (jumpPCBoxWidget != null) {
+            jumpPCBoxWidget.setFocused(false);
+        }
+
         return super.mouseScrolled(mouseX, mouseY, amount, verticalAmount);
     }
 
@@ -58,4 +76,65 @@ public abstract class PCGUIMixin extends Screen {
         GUIHandler.INSTANCE.onPCClose();
     }
 
+    // Feature added by RIze2kNight, 2024
+    //Renders the PC Box Jump widget
+    @Inject(method = "init", at = @At(value = "TAIL"))
+    private void cobblemon_ui_tweaks$init(CallbackInfo ci) {
+
+        var PCBox = storageWidget.getBox() + 1;
+
+        jumpPCBoxWidget = new JumpPCBoxWidget(
+                this.storageWidget,
+                this.pc,
+                ((width - BASE_WIDTH) / 2) + 140,
+                ((height - BASE_HEIGHT) / 2) + 15,
+                60,
+                PC_SPACER_HEIGHT,
+                Component.translatable("cobblemon.ui.pc.box.title", Component.literal(String.valueOf(PCBox)).withStyle(ChatFormatting.BOLD))
+        );
+
+        this.addRenderableWidget(jumpPCBoxWidget);
+    }
+
+    //Stop render original PC Box Title and replace with JumpPCBox + rest of code init + HA highlight renderer
+    @Inject(
+            method = "render",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lcom/cobblemon/mod/common/client/render/RenderHelperKt;drawScaledText$default(Lnet/minecraft/client/gui/GuiGraphics;Lnet/minecraft/resources/ResourceLocation;Lnet/minecraft/network/chat/MutableComponent;Ljava/lang/Number;Ljava/lang/Number;FLjava/lang/Number;IIZZLjava/lang/Integer;Ljava/lang/Integer;ILjava/lang/Object;)V",
+                    ordinal = 12// Target the 13th Box Label occurrence (0-based index)
+            ),
+            cancellable = true               // Allow cancellation if necessary
+    )
+    private void overridePCRender(GuiGraphics context, int mouseX, int mouseY, float delta, CallbackInfo ci) {
+
+        var pokemon = previewPokemon;
+        var x = (width - BASE_WIDTH) / 2;
+        var y = (height - BASE_HEIGHT) / 2;
+
+        super.render(context, mouseX, mouseY, delta);
+
+        /// Item Tooltip
+        if (pokemon != null) {
+            if (!pokemon.getHeldItem$common().isEmpty()) {
+                int itemX = x + 3;
+                int itemY = y + 98;
+                boolean itemHovered =
+                        (mouseX >= itemX && mouseX <= (itemX + 16)) && (mouseY >= itemY && mouseY <= (itemY + 16));
+                if (itemHovered) {
+                    context.renderTooltip(
+                            Minecraft.getInstance().font,
+                            pokemon.heldItemNoCopy$common(),
+                            mouseX,
+                            mouseY
+                    );
+                }
+            }
+
+            OverridedUIRenderer.INSTANCE.renderPC(context,x,y);
+            HAHighlighterRenderer.INSTANCE.renderPC(context,x,y,pokemon);
+        }
+
+        ci.cancel();
+    }
 }

--- a/src/main/kotlin/ca/landonjw/HAHighlighterRenderer.kt
+++ b/src/main/kotlin/ca/landonjw/HAHighlighterRenderer.kt
@@ -1,0 +1,51 @@
+package ca.landonjw
+
+import com.cobblemon.mod.common.api.text.bold
+import com.cobblemon.mod.common.client.gui.pc.PCGUI.Companion.SCALE
+import com.cobblemon.mod.common.client.gui.summary.widgets.screens.info.InfoOneLineWidget
+import com.cobblemon.mod.common.client.render.drawScaledText
+import com.cobblemon.mod.common.pokemon.Pokemon
+import com.cobblemon.mod.common.pokemon.abilities.HiddenAbility
+import com.cobblemon.mod.common.util.asTranslated
+import com.cobblemon.mod.common.util.lang
+import net.minecraft.client.gui.GuiGraphics
+import net.minecraft.network.chat.Style
+import net.minecraft.network.chat.TextColor
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+object HAHighlighterRenderer {      // Feature added by RIze2kNight, 2024
+    private val goldStyle: Style = Style.EMPTY.withColor(TextColor.fromRgb(0xFFD700))
+
+    fun renderPC(context: GuiGraphics, x: Int, y: Int, pokemon: Pokemon) {
+        if(hasHiddenAbility(pokemon)) {
+            drawScaledText(
+                context = context,
+                text = pokemon.ability.displayName.asTranslated().withStyle(goldStyle),
+                x = x + 39,
+                y = y + 154,
+                centered = true,
+                shadow = true,
+                scale = SCALE
+            )
+        }
+    }
+
+    fun renderSummary(x: Int, y: Int, ROW_HEIGHT: Int, width: Int, pokemon: Pokemon): InfoOneLineWidget? {
+        if(hasHiddenAbility(pokemon)) {
+            val abilityWidget = InfoOneLineWidget(
+                pX = x,
+                pY = y + 5 * ROW_HEIGHT,
+                width = width,
+                label = lang("ui.info.ability").bold(),
+                value = pokemon.ability.displayName.asTranslated().bold().withStyle(goldStyle),
+            )
+            return abilityWidget
+        }
+        return null
+    }
+
+    private fun hasHiddenAbility(pokemon: Pokemon): Boolean = pokemon.form.abilities
+        .filterIsInstance<HiddenAbility>()
+        .any { ability -> pokemon.ability.template == ability.template }
+}

--- a/src/main/kotlin/ca/landonjw/JumpPCBoxWidget.kt
+++ b/src/main/kotlin/ca/landonjw/JumpPCBoxWidget.kt
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2023 Cobblemon Contributors
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package ca.landonjw
+
+import com.cobblemon.mod.common.api.text.bold
+import com.cobblemon.mod.common.client.CobblemonResources
+import com.cobblemon.mod.common.client.gui.pc.StorageWidget
+import com.cobblemon.mod.common.client.render.drawScaledText
+import com.cobblemon.mod.common.client.storage.ClientPC
+import com.mojang.blaze3d.platform.InputConstants
+import net.minecraft.client.Minecraft
+import net.minecraft.client.gui.GuiGraphics
+import net.minecraft.client.gui.components.EditBox
+import net.minecraft.client.gui.screens.Screen
+import net.minecraft.network.chat.Component
+import org.slf4j.LoggerFactory
+
+open class JumpPCBoxWidget(     // Feature added by RIze2kNight, 2024
+    private var storageWidget: StorageWidget,
+    private var pc: ClientPC,
+    x: Int,
+    y: Int, width: Int, height: Int, pcBoxText: Component
+): EditBox(
+    Minecraft.getInstance().font,
+    x, y, width, height, pcBoxText
+) {
+    private val logger = LoggerFactory.getLogger("cobblemonuitweaks")
+
+    init {
+        this.setFilter { input -> input.isEmpty() || input.all { it.isDigit() } }
+        logger.info("CobblemonUITweaks JumpPCBoxWidget init")
+
+        setSelectedPCBox(storageWidget.box + 1)
+    }
+
+    override fun setFocused(focused: Boolean) {
+        super.setFocused(focused)
+        this.value = (storageWidget.box + 1).toString()
+    }
+
+    private fun setSelectedPCBox(pcBox: Int) {
+        if (isFocused) {
+            isFocused = false
+        }
+        value = pcBox.toString() // Set the value directly
+    }
+
+    private fun updateNewPCBox() {
+        val newPCBox = this.value.toIntOrNull()
+        if (newPCBox != null && newPCBox > 0 && newPCBox <= pc.boxes.size && newPCBox != storageWidget.box) {
+            storageWidget.box = newPCBox - 1 // Update storage widget
+            value = (newPCBox).toString()
+        }
+        else{
+            this.value = storageWidget.box.toString()
+        }
+    }
+
+    override fun renderWidget(context: GuiGraphics, mouseX: Int, mouseY: Int, delta: Float) {
+        if (cursorPosition != value.length) moveCursorToEnd(Screen.hasShiftDown())
+        val currentBox = this.storageWidget.box + 1     // Dynamically fetch current box for rendering
+
+        drawScaledText(
+            context = context,
+            font = CobblemonResources.DEFAULT_LARGE,
+            text = Component.translatable("cobblemon.ui.pc.box.title", if (isFocused) "$value|" else currentBox).bold(),
+            x = x + 172 - 140,
+            y = y,
+            centered = true
+        )
+    }
+
+    override fun keyPressed(keyCode: Int, scanCode: Int, modifiers: Int): Boolean {
+        if (keyCode == InputConstants.KEY_RETURN) { // Enter key
+            updateNewPCBox()
+            this.isFocused = false
+            return true
+        } else if (keyCode == InputConstants.KEY_ESCAPE) { // Escape key to cancel changes
+            this.value = storageWidget.box.toString()
+            this.isFocused = false
+            return true
+        }
+        return super.keyPressed(keyCode, scanCode, modifiers)
+    }
+}

--- a/src/main/kotlin/ca/landonjw/OverridedUIRenderer.kt
+++ b/src/main/kotlin/ca/landonjw/OverridedUIRenderer.kt
@@ -1,0 +1,48 @@
+package ca.landonjw
+
+import com.cobblemon.mod.common.api.gui.blitk
+import com.cobblemon.mod.common.client.gui.pc.PCGUI.Companion.PC_SPACER_HEIGHT
+import com.cobblemon.mod.common.client.gui.pc.PCGUI.Companion.PC_SPACER_WIDTH
+import com.cobblemon.mod.common.client.gui.pc.PCGUI.Companion.SCALE
+import com.cobblemon.mod.common.util.cobblemonResource
+import net.minecraft.client.gui.GuiGraphics
+
+object OverridedUIRenderer {        // Feature added by RIze2kNight, 2024
+
+    fun renderPC(context: GuiGraphics, x: Int, y: Int) {
+        val matrices = context.pose()
+        val topSpacerResource = cobblemonResource("textures/gui/pc/pc_spacer_top.png")
+        val bottomSpacerResource = cobblemonResource("textures/gui/pc/pc_spacer_bottom.png")
+        val rightSpacerResource = cobblemonResource("textures/gui/pc/pc_spacer_right.png")
+
+        blitk(
+            matrixStack = matrices,
+            texture = topSpacerResource,
+            x = (x + 86.5) / SCALE,
+            y = (y + 13) / SCALE,
+            width = PC_SPACER_WIDTH,
+            height = PC_SPACER_HEIGHT,
+            scale = SCALE
+        )
+
+        blitk(
+            matrixStack = matrices,
+            texture = bottomSpacerResource,
+            x = (x + 86.5) / SCALE,
+            y = (y + 189) / SCALE,
+            width = PC_SPACER_WIDTH,
+            height = PC_SPACER_HEIGHT,
+            scale = SCALE
+        )
+
+        blitk(
+            matrixStack = matrices,
+            texture = rightSpacerResource,
+            x = (x + 275.5) / SCALE,
+            y = (y + 184) / SCALE,
+            width = 64,
+            height = 24,
+            scale = SCALE
+        )
+    }
+}

--- a/src/main/resources/cobblemon-ui-tweaks.mixins.json
+++ b/src/main/resources/cobblemon-ui-tweaks.mixins.json
@@ -3,16 +3,17 @@
 	"package": "ca.landonjw.mixin",
 	"compatibilityLevel": "JAVA_17",
 	"mixins": [
-		"pc.PCGUIMixin",
-		"pc.StorageWidgetMixin",
-		"pc.SummaryMixin",
-		"pc.NicknameEntryWidgetMixin",
+		"battle.log.BattleMessageHandlerMixin",
 		"battle.log.BattleMessagePaneMixin",
 		"battle.log.ClientBattleMessageQueueMixin",
-		"battle.log.BattleMessageHandlerMixin",
-		"pc.StatWidgetMixin",
+		"battle.move.BattleMoveSelectionMixin",
 		"battle.portrait.BattleGuiMixin",
-		"battle.move.BattleMoveSelectionMixin"
+		"pc.NicknameEntryWidgetMixin",
+		"pc.PCGUIMixin",
+		"pc.StatWidgetMixin",
+		"pc.StorageWidgetMixin",
+		"pc.SummaryMixin",
+		"pc.InfoWidgetMixin"
 	],
 	"injectors": {
 		"defaultRequire": 1


### PR DESCRIPTION
The method now uses verticalAmount parameter as the value for how much the normal mousewheel is scrolled.
"amount" is not tied to horizontal scrolling, which is also kinda buggy since i used my horizontal scroll wheel on my mouse and still did not update the PC box