### PR TITLE
Fix PC mouse scrolling

### DIFF
--- a/src/main/java/ca/landonjw/mixin/pc/PCGUIMixin.java
+++ b/src/main/java/ca/landonjw/mixin/pc/PCGUIMixin.java
@@ -41,7 +41,7 @@ public abstract class PCGUIMixin extends Screen {
             pastureWidget.getPastureScrollList().mouseScrolled(mouseX, mouseY, amount, verticalAmount);
         }
         else {
-            var newBox = (storageWidget.getBox() - (int)amount) % this.pc.getBoxes().size();
+            var newBox = (storageWidget.getBox() - (int)verticalAmount) % this.pc.getBoxes().size();
             storageWidget.setBox(newBox);
         }
 


### PR DESCRIPTION
- amount is now horizontal scroll amount, and does not work with regular scrolling (also does not work with my mouse's horizontal scroll wheel)
- replaced with verticalAmount to get actual value for regular mouse scrolling